### PR TITLE
add GNU/Linux section under Development/Unit tests

### DIFF
--- a/docs/org_noter_tech_notes.org
+++ b/docs/org_noter_tech_notes.org
@@ -159,3 +159,15 @@ Omitting the header causes =org-noter--parse-root= to work incorrectly.
   cask                     # install dependencies
   cask exec buttercup -L . # exec unit tests, in the root of the project
 #+end_src
+
+*** GNU/Linux
+
+#+begin_src shell
+  git clone https://github.com/cask/cask.git
+  make -C cask install
+  cask
+
+  cd <to-project-path>
+  cask exec buttercup -L .
+#+end_src
+=> ~/.local/bin/cask: line 53: buttercup: command not found


### PR DESCRIPTION
I have buttercup installed and loaded by my config, but I get the errror message below the src block.